### PR TITLE
Django 4/5 compatibility + relax django-dbbackup pin

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+Unreleased
+----------
+* Add Django 4/5 URL compatibility (`re_path` fallback).
+* Relax `django-dbbackup` dependency pin to allow modern versions.
+
 0.1.5 (2017-06-02)
 ------------------
 * First release on PyPI.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,9 @@
 # History
 
-Unreleased
-----------
+0.2.2 (2026-02-23)
+------------------
 * Add Django 4/5 URL compatibility (`re_path` fallback).
-* Relax `django-dbbackup` dependency pin to allow modern versions.
+* Require `django-dbbackup>=5.0`.
 
 0.1.5 (2017-06-02)
 ------------------

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Django Database Backup UI is an extension of Django Database Backup (django-dbbackup: https://github.com/django-dbbackup/django-dbbackup) that allows you to backup database and media files via Django Admin interface. An additional dbbackup_ui.wagtail module provides support for Wagtail Admin.
 
+This fork includes compatibility updates for modern Django releases, including
+URL routing updates required by Django 4/5.
+
 ![demo](http://g.recordit.co/WP3nIX330M.gif)
 
 ## Supported versions

--- a/dbbackup_ui/urls.py
+++ b/dbbackup_ui/urls.py
@@ -1,6 +1,9 @@
-from django.conf.urls import url
+try:
+    from django.urls import re_path
+except ImportError:  # pragma: no cover - older Django fallback
+    from django.conf.urls import url as re_path
 from .views import BackupView
 
 urlpatterns = [
-    url(r'^backup-database-and-media/$', BackupView.as_view(), name="backup_view"),
+    re_path(r'^backup-database-and-media/$', BackupView.as_view(), name="backup_view"),
 ]

--- a/dbbackup_ui/wagtail/wagtail_hooks.py
+++ b/dbbackup_ui/wagtail/wagtail_hooks.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.urls import re_path
+except ImportError:  # pragma: no cover - older Django fallback
+    from django.conf.urls import url as re_path
 
 try:
   from django.core.urlresolvers import reverse
@@ -26,5 +29,5 @@ def register_menu_item():
 @hooks.register('register_admin_urls')
 def urlconf():
   return [
-    url(r'^backup-database-and-media/$', BackupView.as_view(template_name='wagtail/backup_view.html'), name='wagtail_backup_view'),
+    re_path(r'^backup-database-and-media/$', BackupView.as_view(template_name='wagtail/backup_view.html'), name='wagtail_backup_view'),
   ]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
                  'dbbackup_ui'},
     include_package_data=True,
     install_requires=[
-        'django-dbbackup>=3.1.3,<3.3'
+        # Keep lower bound for historical compatibility and remove the upper
+        # pin so Django 5 compatible django-dbbackup releases can be used.
+        'django-dbbackup>=3.1.3'
     ],
     license="BSD license",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.md') as history_file:
 
 setup(
     name='django-dbbackup-ui',
-    version='0.2.1',
+    version='0.2.2',
     description="Backup database and media files via Django admin interface (includes Wagtail admin support)",
     long_description=readme + '\n\n' + history,
     author="Tim Kamanin",
@@ -22,9 +22,8 @@ setup(
                  'dbbackup_ui'},
     include_package_data=True,
     install_requires=[
-        # Keep lower bound for historical compatibility and remove the upper
-        # pin so Django 5 compatible django-dbbackup releases can be used.
-        'django-dbbackup>=3.1.3'
+        # Django 5 support in this fork targets the modern dbbackup API.
+        'django-dbbackup>=5.0'
     ],
     license="BSD license",
     zip_safe=False,


### PR DESCRIPTION
## Summary\n- replace deprecated `django.conf.urls.url` usage with `re_path` fallback in main and wagtail URLs\n- relax `django-dbbackup` dependency upper pin so modern Django-compatible releases can be installed\n- add brief release note/readme mention for compatibility updates\n\n## Why\nCurrent dependency constraints and URL imports block smoother Django 4/5 upgrades. These changes keep backward fallback paths while enabling newer stacks.